### PR TITLE
Fix another double free

### DIFF
--- a/src/beectl.c
+++ b/src/beectl.c
@@ -77,7 +77,7 @@ which (char *executable, size_t executable_size)
   assert (executable != NULL);
 
   if (is_absolute_path (executable, executable_size))
-    return executable;
+    return strdup(executable);
 
   if (unlikely ((org_path = getenv ("PATH")) == NULL))
     {

--- a/src/beectl.c
+++ b/src/beectl.c
@@ -77,7 +77,7 @@ which (char *executable, size_t executable_size)
   assert (executable != NULL);
 
   if (is_absolute_path (executable, executable_size))
-    return strdup(executable);
+    return strdup (executable);
 
   if (unlikely ((org_path = getenv ("PATH")) == NULL))
     {


### PR DESCRIPTION
## Problem:

`beectl` crashes when it's given an absolute editor path.


## Explanation:

*`editor_path` used below is an alias to `cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive (obj, "editor")`*

- With no shell command or editor name (not absolute) defined in the extension options:
    - `editor_path` contains empty string at `0xA`
    - with no command passed, `obj` doesn't contains the editor path so `get_editor()` returns `NULL` and `get_alternative_editor()` is called -> new memory address != `editor_path`
    - with the relative path passed, `get_editor()` needs to generate the absolute path from the relative path -> new memory address != `editor_path`
    - `editor_args[0]` contains editor path at `0xB` 


    - When entering `_ret`:
        1. all `editor_args` are freed including 0xB
        2. `cJSON_Delete()` is called and recursively frees all the `obj` elements including `editor_path` which wasn't freed before -> beectl terminates normally


- With a shell command (editor absolute path) defined in the extension options:
    - `editor_path` contains editor path at `0xA`
    - `obj` contains the editor absolute path so `get_editor()` directly passes the address extracted from obj i.e. `0xA`
    - `editor_args[0]` contains editor path at `0xA` 

    - When entering `_ret`:
        1. all `editor_args` are freed including 0xA
        2. `cJSON_Delete()` is called and recursively frees all the `obj` elements including `editor_path` but the address was already freed -> double free and beectl crashes

## Solutions:

- Allocate a new address when the path is absolute in `which()` or for the first arg in `get_editor_args()` 
- Check if the address of `editor_path` and editor_args[0] matches before freeing in `_ret`

~~In this PR I opted for the latter so no new memory address needs to be allocated.~~
Creating a new address with `strdup` is simpler and follows what `which()` was already doing.

## Comments:

Part of dc9200e7d5a79427d7cfdb3535d542939499777d solves a related double free between `editor` and `editor_args`, most notably only freeing `editor` if the address is different from `editor_args[0]`.

I thought some pseudo-code would help summarize a bit:

Variables used in both pseudo-codes:

```
a = 0x1 // editor
*b = [a, 0x2] // editor_args
*c = [0x3, b] // oversimplification of JSON obj
```

- The double free the commit above solves

```
foreach e in b:
    free(e) -> 'a' freed

free(a) -> 'a' double freed
```

- The double free this PR solves


```
foreach e in b:
    free(e) -> 'a' freed

foreach t in c: // oversimplification of what cJSON_Delete() does (recurses otherwise)
    foreach e in t
        free(e) -> 'a' double freed
```
